### PR TITLE
Implement kernel policy cache override.

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -26,9 +26,12 @@
 	"obj.CreateRestorePoint \"%s\", 0, 100\nWScript.Quit 123"
 
 #define POLICY_KEY "System\\CurrentControlSet\\Control\\ProductOptions"
-#define PRODUCT_POLICY L"ProductPolicy"
-#define CUSTOM_POLICY L"CustomPolicy"
+#define PRODUCT_POLICY "ProductPolicy"
+#define CUSTOM_POLICY "CustomPolicy"
+
 #define NT_MACHINE L"\\Registry\\Machine\\"
+
+#define POLICY_PATH NT_MACHINE POLICY_KEY
 #define SVC_BASE NT_MACHINE "System\\CurrentControlSet\\Services\\"
 #define LOAD_ATTEMPTS 8
 

--- a/wind.h
+++ b/wind.h
@@ -14,7 +14,10 @@ typedef struct {
 	int 	protbit;   // Flags2->ProtectedProcess bit on Win7, -1 otherwise.
 	int 	bootreg;   // process registry entries at boot
 	LIST_ENTRY *cblist;
+	NTSTATUS NTAPI (*pExUpdateLicenseData)(ULONG,PVOID);
+	NTSTATUS __fastcall (*pExUpdateLicenseData2)(ULONG,PVOID);
 } wind_config_t;
+#define WIND_POL_MAX 512
 
 #define WIND_IOCTL_REGCBOFF CTL_CODE(FILE_DEVICE_UNKNOWN, 0x800, METHOD_BUFFERED, FILE_ANY_ACCESS)
 #define WIND_IOCTL_REGCBON CTL_CODE(FILE_DEVICE_UNKNOWN, 0x801, METHOD_BUFFERED, FILE_ANY_ACCESS)
@@ -43,6 +46,71 @@ typedef struct {
 	LONG_PTR pid; 		// Pid this is for. Negative = get flags only.
 	WIND_PS_PROTECTION prot;// New protection flags. Old flags stored in there.
 } wind_prot_t;
+
+// Policy header
+typedef struct {
+	ULONG 	sz; 		// Size of everything.
+	ULONG 	data_sz; 	// Always sz-0x18.
+	ULONG 	endpad; 	// End padding. Usually 4.
+	ULONG 	tainted; 	// 1 if tainted.
+	ULONG 	pad1; 		// Always 1
+} __attribute((packed)) wind_pol_hdr;
+
+// Policy entry
+typedef struct {
+	USHORT  sz; 		// Size of whole entry.
+	USHORT 	name_sz; 	// Size of the following field, in bytes.
+	USHORT 	type; 		// Field type
+	USHORT 	data_sz; 	// Field size
+	ULONG 	flags; 		// Field flags
+	ULONG 	pad0; 		// Always 0
+	UCHAR 	name[0]; 	// WCHAR name, NOT zero terminated!
+} __attribute__((packed)) wind_pol_ent;
+
+static int wind_pol_unpack(UCHAR *blob, wind_pol_ent **array)
+{
+	wind_pol_hdr *h = (void*)blob;
+	wind_pol_ent *e = (void*)blob + sizeof(*h);
+	void *endptr = ((void*)e) + h->data_sz;
+	int n = 0;
+	// Unusual.
+	if (h->sz >= 65536)
+		return -1;
+	if (h->endpad != 4)
+		return -2;
+	if (h->data_sz+0x18 != h->sz)
+		return -3;
+	if (blob[h->sz-4] != 0x45)
+		return -4;
+	while (((void*)e) < endptr) {
+		array[n++] = e;
+		e = ((void*)e) + e->sz;
+		if (n == WIND_POL_MAX)
+			return -1;
+	}
+	return n;
+}
+
+static int wind_pol_pack(UCHAR *dst, wind_pol_ent **array, int n)
+{
+	wind_pol_hdr *h = (void*)dst;
+	wind_pol_ent *e = (void*)dst + sizeof(*h);
+	int i = 0;
+	memset(dst, 0, 65536);
+	for (i = 0; i < n; i++) {
+		int total = sizeof(*e) + array[i]->name_sz + array[i]->data_sz;
+		memcpy(e, array[i], total);
+		total = (total + 4) & (~3);
+		e->sz = total;
+		e = ((void*)e) + total;
+		h->data_sz += total;
+	}
+	h->sz = h->data_sz + 0x18;
+	h->endpad = 4;
+	h->pad1 = 1;
+	dst[h->sz-4] = 0x45;
+	return h->sz;
+}
 
 // Open the kernel driver
 #ifndef _WIND_DRIVER


### PR DESCRIPTION
Let's try some documentation this time :)

WinD can now override some really dumb policies.

For example if you want to sideload metro apps:

```
[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\ProductOptions\CustomPolicy]
"WSLicensingService-EnableLOBApps"=dword:00000001
"WSLicensingService-LOBSideloadingActivated"=dword:00000001
```

Or want to join a domain?

```
[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\ProductOptions\CustomPolicy]
"WorkstationService-DomainJoinEnabled"=dword:00000001
```

And there are many, many more interesting ones.

`HKLM\SYSTEM\CurrentControlSet\Control\ProductOptions\ProductPolicy` is now basically shadowed by values from `CustomPolicy` subkey (no blob, for convenience).

All changes are reflected in real time, no reboots needed etc.

For more details, see http://www.geoffchappell.com/notes/windows/license/install.htm and also http://forums.mydigitallife.info/threads/39411-Windows-Product-Policy-Editor
